### PR TITLE
Update scripts to run on Apache web server on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,28 @@ an infinite scroll app for apache web server
 - Apache web server
 - Node.js and npm
 - PHP
+
+## Windows-Specific Setup Instructions
+
+1. Ensure you have Apache installed on your Windows system. You can download it from the [Apache Lounge](https://www.apachelounge.com/download/).
+
+2. Install PHP for Windows. You can download it from the [PHP for Windows](https://windows.php.net/download/) website.
+
+3. Configure Apache to work with PHP by adding the following lines to your `httpd.conf` file:
+   ```
+   LoadModule php_module "C:/path/to/php/php7apache2_4.dll"
+   AddHandler application/x-httpd-php .php
+   PHPIniDir "C:/path/to/php"
+   ```
+
+4. Ensure the `generate_thumbnails.php` script is executable on Windows. You can do this by right-clicking the file, selecting "Properties", and ensuring the "Read-only" attribute is unchecked.
+
+5. Update the image directory path in the `generate_thumbnails.php` script to use Windows-specific paths, e.g., `C:\\path\\to\\your\\images\\directory`.
+
+6. Restart Apache to apply the changes.
+
+## Windows-Specific Configuration
+
+1. Ensure the `generate_thumbnails.php` script is executable and accessible by the Apache server.
+
+2. Configure the image directory path in the `generate_thumbnails.php` script to use Windows-specific paths, e.g., `C:\\path\\to\\your\\images\\directory`.

--- a/generate_thumbnails.php
+++ b/generate_thumbnails.php
@@ -1,12 +1,18 @@
 <?php
 
-$imagesDir = 'path/to/your/images/directory';
-$thumbnailsDir = 'path/to/your/thumbnails/directory';
+$imagesDir = 'C:\\path\\to\\your\\images\\directory';
+$thumbnailsDir = 'C:\\path\\to\\your\\thumbnails\\directory';
 $thumbnailWidth = 300;
 $thumbnailHeight = 200;
 
-if (!file_exists($thumbnailsDir)) {
-    mkdir($thumbnailsDir, 0777, true);
+if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+    if (!file_exists($thumbnailsDir)) {
+        mkdir($thumbnailsDir, 0777, true);
+    }
+} else {
+    if (!file_exists($thumbnailsDir)) {
+        mkdir($thumbnailsDir, 0755, true);
+    }
 }
 
 $page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
@@ -20,8 +26,8 @@ $images = array_slice($images, $offset, $imagesPerPage);
 $response = ['images' => []];
 
 foreach ($images as $image) {
-    $imagePath = $imagesDir . '/' . $image;
-    $thumbnailPath = $thumbnailsDir . '/' . $image;
+    $imagePath = $imagesDir . '\\' . $image;
+    $thumbnailPath = $thumbnailsDir . '\\' . $image;
 
     if (!file_exists($thumbnailPath)) {
         createThumbnail($imagePath, $thumbnailPath, $thumbnailWidth, $thumbnailHeight);


### PR DESCRIPTION
Update the scripts to run on Apache web server on Windows.

* **generate_thumbnails.php**
  - Update `$imagesDir` and `$thumbnailsDir` variables to use Windows-specific paths.
  - Add a check to ensure the script is running on a Windows system.
  - Update the `mkdir` function to use Windows-specific permissions.
  - Modify image paths to use backslashes for Windows compatibility.

* **README.md**
  - Add Windows-specific setup instructions for running the app on an Apache web server.
  - Update the configuration section to include Windows-specific paths.
  - Add a note about ensuring the `generate_thumbnails.php` script is executable on Windows.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/infinite-scroll?shareId=b4a33949-5d5c-4c1a-8392-e73ef871e611).